### PR TITLE
Overload "DownloadFile" with an option for asynchronous progress

### DIFF
--- a/BlazorDownloadFile/BlazorDownloadFile.csproj
+++ b/BlazorDownloadFile/BlazorDownloadFile.csproj
@@ -15,9 +15,9 @@
     <Copyright>Anthony G. Rivera Cosme</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <Version>2.3.1.1</Version>
-    <AssemblyVersion>2.3.1.1</AssemblyVersion>
-    <FileVersion>2.3.1.1</FileVersion>
+    <Version>2.3.1.2</Version>
+    <AssemblyVersion>2.3.1.2</AssemblyVersion>
+    <FileVersion>2.3.1.2</FileVersion>
   </PropertyGroup>
 
 

--- a/BlazorDownloadFile/Service/BlazorDownloadFileService.cs
+++ b/BlazorDownloadFile/Service/BlazorDownloadFileService.cs
@@ -276,6 +276,20 @@ namespace BlazorDownloadFile
             return await JSRuntime.InvokeAsync<DownloadFileResult>("_blazorDowloadFileByteArrayPartitioned", fileName, contentType);
         }
         /// <inheritdoc/>
+        public async ValueTask<DownloadFileResult> DownloadFile(string fileName, byte[] bytes, int bufferSize = 32768, string contentType = "application/octet-stream", Func<double, Task>? progress = null)
+        {
+            await ClearBuffers();
+            var bytesReaded = 0;
+            foreach (var partFile in Partition(bytes, bufferSize))
+            {
+                bytesReaded += partFile.Count;
+                var totalProgress = (double)bytesReaded / bytes.Length;
+                await progress?.Invoke(totalProgress);
+                await JSRuntime.InvokeVoidAsync("_blazorDownloadFileBuffersPush", partFile);
+            }
+            return await JSRuntime.InvokeAsync<DownloadFileResult>("_blazorDowloadFileByteArrayPartitioned", fileName, contentType);
+        }
+        /// <inheritdoc/>
         public async ValueTask<DownloadFileResult> DownloadFile(string fileName, byte[] bytes, CancellationToken cancellationToken, int bufferSize = 32768, string contentType = "application/octet-stream", IProgress<double>? progress = null)
         {
             await ClearBuffers();

--- a/BlazorDownloadFile/Service/IBlazorDownloadFileService.cs
+++ b/BlazorDownloadFile/Service/IBlazorDownloadFileService.cs
@@ -339,6 +339,16 @@ namespace BlazorDownloadFile
         /// </summary>
         /// <param name="fileName">The filename</param>
         /// <param name="bytes">The bytes of the file</param>
+        /// <param name="bufferSize">The buffer size</param>
+        /// <param name="contentType">The file content type</param>
+        /// <param name="progress">The progress percent of data transfered</param>
+        /// <returns></returns>
+        ValueTask<DownloadFileResult> DownloadFile(string fileName, byte[] bytes, int bufferSize = 32768, string contentType = "application/octet-stream", Func<double, Task>? progress = null);
+        /// <summary>
+        /// Download a file from blazor context to the browser
+        /// </summary>
+        /// <param name="fileName">The filename</param>
+        /// <param name="bytes">The bytes of the file</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <param name="bufferSize">The buffer size</param>
         /// <param name="contentType">The file content type</param>


### PR DESCRIPTION
The existing "IProgress" options are not working well for me in Blazor WASM on .NET 6.0.

I want to update my UI every time the progress updates.  Instead, none of the progress updates fire until the download completes.  My progress bar shoots from 0% to 100% in an instant.

This `Func<double, Task>` option works much better.  My usage:

```
await BlazorDownloadFileService.DownloadFile(FileName, DecryptedFile, downloadBufferSize, ContentType, UpdateDownloadProgressAsync);

protected async Task UpdateDownloadProgressAsync(double value)
{
    DownloadProgressPercent = value;
    await Task.Delay(5);  // Give the UI a moment to update
    StateHasChanged();  // May not be necessary
    Console.WriteLine(value);  // Debug
}
```